### PR TITLE
Update rmccue/requests dependency to 2.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=7.4|>=8.0",
         "ext-json": "*",
-        "rmccue/requests": "^1.8"
+        "rmccue/requests": "^2.0"
     },
     "autoload": {
         "psr-4": { "Geniem\\LinkedEvents\\" : "src/" }

--- a/src/LinkedEventsClient.php
+++ b/src/LinkedEventsClient.php
@@ -6,7 +6,7 @@
 namespace Geniem\LinkedEvents;
 
 use Exception;
-use Requests;
+use WpOrg\Requests\Requests;
 use stdClass;
 
 /**


### PR DESCRIPTION
This is done in the hopes of improving compatibility with PHP 8.1.

Quick testing on tampere.fi seems to indicate that the compatibility has been fixed and that at least our use case is intact.